### PR TITLE
fix: use file input in build actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
         platforms: ${{ inputs.platform }}
         push: false
         tags: ${{ inputs.tags }}
@@ -93,6 +94,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
         platforms: ${{ inputs.platform }}
         push: ${{ inputs.push }}
         tags: ${{ inputs.tags }}


### PR DESCRIPTION
Although we are accepting `file` input, we are not using it in our steps. This PR will fix this.