### PR TITLE
fix: prevent multiarch docker image scan errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
-        platforms: ${{ inputs.platforms }}
+        platforms: linux/amd64
         push: false
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}


### PR DESCRIPTION
trufflehog is failing to scan multiarch docker images. To avoid this issue we will be scanning only `linux/amd64` platform docker images until we figure out a solution to scan multiarch docker images.