### PR TITLE
feature: load_target and push_target options are introduced

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,12 @@ inputs:
   tags:
     description: "List of tags"
     required: false
+  load_target:
+    description: "Target stage to load for local use"
+    required: false
+  push_target:
+    description: "Target stage to push to registry"
+    required: false
 
 outputs:
   imageid:
@@ -75,6 +81,7 @@ runs:
         secret-envs: ${{ inputs.secret-envs }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
+        target: ${{ inputs.load_target }}
         outputs: type=docker,dest=${{ runner.temp }}/local-docker-image.tar
 
     - name: Scan docker image with TruffleHog
@@ -105,6 +112,7 @@ runs:
         secret-envs: ${{ inputs.secret-envs }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
+        target: ${{ inputs.push_target }}
 
     - name: Sign the images with GitHub OIDC Token
       env:


### PR DESCRIPTION
## Description of the change

Transformer uses the `load_target` and `push_target` fields from 
https://linear.app/rudderstack/issue/INT-3167/github-actions-update-the-docker-build-action-library 
This PR enhances the current functionality to include these fields.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
