### PR TITLE
fix: install cosign before signing images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,9 @@ runs:
         cache-to: ${{ inputs.cache-to }}
         target: ${{ inputs.target }}
 
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.6.0
+
     - name: Sign the images with GitHub OIDC Token
       env:
         DIGEST: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Install cosign tool before signing images. This avoids errors where cosign is not already installed.