### PR TITLE
fix: multi platform build issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,12 +66,21 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Select single platform
+      id: select-single-platform
+      shell: bash
+      run: |
+        if [[ "${{ inputs.platforms }}" == *","* || "${{ inputs.platforms }}" == *"["* || "${{ inputs.platforms }}" == *"-"* ]]; then
+          echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+        else
+          echo "platform=${{ inputs.platforms }}" >> $GITHUB_OUTPUT
+        fi
     - name: Build image
       uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
-        platforms: linux/amd64
+        platforms: ${{ steps.select-single-platform.outputs.platform }}
         push: false
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}


### PR DESCRIPTION
## Description of the change

Trufflehog doesn't support scanning [oci](https://docs.docker.com/reference/cli/docker/buildx/build/#oci) output format (when platforms is a list). So whenever inputs.platforms is an list/csv we use `linux/amd64` platform or else we directly use inputs.platforms 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
