### PR TITLE
feat: ignore paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ This action does the following:
    (when push is set to `true`).
 4. Signs the docker image
 
-
 ## permissions
 
-GitHub Actions can use Fulcio to sign images. Fulcio is a root CA that issues signing certificates from OIDC tokens. 
+GitHub Actions can use Fulcio to sign images. Fulcio is a root CA that issues signing certificates from OIDC tokens.
 Add the following below permissions for image siging in your workflow at root level. [eg](https://github.com/rudderlabs/rudderstack-operator/blob/f3d326ddcb207fb8f42b587d6307f338479c2540/.github/workflows/build-pr.yaml#L10)
 
 ```
@@ -26,7 +25,6 @@ Add the following below permissions for image siging in your workflow at root le
   contents: read
 ```
 
-
 ## Usage
 
 Replace `docker/build-push-action@vX` with `rudderlabs/build-scan-push-action@v1.x`
@@ -34,6 +32,12 @@ in your GitHub Workflows.
 
 For more info, refer the documentation of
 [docker-build-push](https://github.com/docker/build-push-action) GitHub Action.
+
+## Ignoring false positives
+
+TruffleHog doesn't support excluding file paths (to ignore false positives) when
+scanning docker images. We wrote a python script that reads regular expressions
+from `trufflehog-ignore` and excludes all paths that match these regular expressions
 
 ## Current Limitations
 

--- a/action.yml
+++ b/action.yml
@@ -93,20 +93,6 @@ runs:
         target: ${{ inputs.target }}
         outputs: type=docker,dest=${{ runner.temp }}/local-docker-image.tar
 
-    #- name: Create file with paths to be excluded from scan
-    #  shell: bash
-    #  run: |
-    #    cat <<EOF > ${{ runner.temp }}/excluded.txt
-    #    .*node_modules.*
-    #    .*site-packages.*
-    #    ^/opt/helm/helm-charts.*
-    #    ^/usr/lib.*
-    #    ^/usr/share.*
-    #    ^/usr/local.*
-    #    ^/var/lib/apt.*
-    #    ^/var/lib/dpkg.*
-    #    EOF
-
     - name: Setup python
       uses: actions/setup-python@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,7 @@ runs:
         else
           echo "platform=${{ inputs.platforms }}" >> $GITHUB_OUTPUT
         fi
+
     - name: Build image
       uses: docker/build-push-action@v6
       with:
@@ -92,16 +93,44 @@ runs:
         target: ${{ inputs.target }}
         outputs: type=docker,dest=${{ runner.temp }}/local-docker-image.tar
 
-    - name: Scan docker image with TruffleHog
+    #- name: Create file with paths to be excluded from scan
+    #  shell: bash
+    #  run: |
+    #    cat <<EOF > ${{ runner.temp }}/excluded.txt
+    #    .*node_modules.*
+    #    .*site-packages.*
+    #    ^/opt/helm/helm-charts.*
+    #    ^/usr/lib.*
+    #    ^/usr/share.*
+    #    ^/usr/local.*
+    #    ^/var/lib/apt.*
+    #    ^/var/lib/dpkg.*
+    #    EOF
+
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install TruffleHog
       shell: bash
       run: |
-        docker pull trufflesecurity/trufflehog:latest
-        docker run --rm -v ${{ runner.temp }}:/tmp \
-          trufflesecurity/trufflehog:latest \
-          docker --image file:///tmp/local-docker-image.tar \
-          --github-actions \
-          --no-verification \
-          --fail
+        TRUFFLEHOG_VERSION="3.88.5"
+        echo "Installing TruffleHog version $TRUFFLEHOG_VERSION"
+        curl -sL "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz" -o trufflehog.tar.gz
+        tar -xzf trufflehog.tar.gz
+        chmod +x trufflehog
+
+        sudo mv trufflehog /usr/local/bin/
+
+        # Cleanup
+        rm trufflehog.tar.gz
+
+    - name: Scan docker image with TruffleHog
+      id: scan-docker-image
+      shell: bash
+      run: |
+        python $GITHUB_ACTION_PATH/docker-image-scanner.py ${{ runner.temp }}/local-docker-image.tar $GITHUB_ACTION_PATH/trufflehog-ignore
 
     - name: Build and push
       id: build-and-push

--- a/docker-image-scanner.py
+++ b/docker-image-scanner.py
@@ -27,7 +27,14 @@ def scan_docker_image(image_path: str) -> List[Dict]:
     """Scan Docker image using trufflehog and return JSON results."""
     try:
         formatted_path = format_image_path(image_path)
-        cmd = ["trufflehog", "docker", "--image", formatted_path, "--json"]
+        cmd = [
+            "trufflehog",
+            "docker",
+            "--image",
+            formatted_path,
+            "--json",
+            "--no-verification",
+        ]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         if result.returncode != 0:

--- a/docker-image-scanner.py
+++ b/docker-image-scanner.py
@@ -1,0 +1,103 @@
+import json
+import os
+import sys
+import re
+import subprocess
+
+from typing import List, Dict
+
+
+def load_regex_patterns(regex_file: str) -> List[str]:
+    """Load regex patterns from a file."""
+    try:
+        with open(regex_file, "r") as f:
+            return [line.strip() for line in f if line.strip()]
+    except FileNotFoundError:
+        print(f"Error: Regex file '{regex_file}' not found", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_image_path(image_path: str) -> str:
+    """Format the image path to use file:/// prefix with absolute path."""
+    abs_path = os.path.abspath(image_path)
+    return f"file://{abs_path}"
+
+
+def scan_docker_image(image_path: str) -> List[Dict]:
+    """Scan Docker image using trufflehog and return JSON results."""
+    try:
+        formatted_path = format_image_path(image_path)
+        cmd = ["trufflehog", "docker", "--image", formatted_path, "--json"]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(f"Error running trufflehog: {result.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+        # Process output line by line as each line is a JSON object
+        findings = []
+        for line in result.stdout.splitlines():
+            if line.strip():
+                try:
+                    findings.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        return findings
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing trufflehog: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def filter_results(findings: List[Dict], patterns: List[str]) -> List[Dict]:
+    """Filter findings based on regex patterns."""
+    if not patterns:
+        return findings
+
+    compiled_patterns = [re.compile(pattern) for pattern in patterns]
+    filtered_findings = []
+
+    for finding in findings:
+        raw_result = str(finding["SourceMetadata"]["Data"]["Docker"]["file"])
+        if any(pattern.search(raw_result) for pattern in compiled_patterns):
+            continue
+
+        filtered_findings.append(finding)
+
+    return filtered_findings
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python scanner.py <docker_image.tar> [regex_file]", file=sys.stderr
+        )
+        sys.exit(1)
+
+    image_path = sys.argv[1]
+    regex_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+    patterns = load_regex_patterns(regex_file) if regex_file else []
+
+    findings = scan_docker_image(image_path)
+
+    # Filter results if patterns provided
+    if patterns:
+        findings = filter_results(findings, patterns)
+
+    # Output results
+    if findings:
+        for finding in findings:
+            file = finding["SourceMetadata"]["Data"]["Docker"]["file"]
+            layer = finding["SourceMetadata"]["Data"]["Docker"]["layer"]
+            redacted_secret = finding["Redacted"]
+            print(
+                f"Found unverified secret {redacted_secret} in file={file} layer={layer}"
+            )
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/trufflehog-ignore
+++ b/trufflehog-ignore
@@ -1,0 +1,8 @@
+.*node_modules.*
+.*site-packages.*
+^/opt/helm/helm-charts.*
+^/usr/lib.*
+^/usr/share.*
+^/usr/local.*
+^/var/lib/apt.*
+^/var/lib/dpkg.*


### PR DESCRIPTION
Trufflehog doesn't support ignoring false positives in docker images. We implement this using a python script which filters findings based on regular expressions in trufflehog-ignore file
