### PR TITLE
chore: update main branch with the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-GitHub Action to build, scan, sign and push Docker images. This is a thin wrapper
+GitHub Action to build, scan and push Docker images. This is a thin wrapper
 around [docker-build-push](https://github.com/docker/build-push-action) GitHub action.
 
 This action does the following:
@@ -12,36 +12,11 @@ This action does the following:
    - GitHub action fails if secrets are found in the docker image
 3. Pushes the docker image to a docker repository if no secrets are found
    (when push is set to `true`).
-4. Signs the docker image
-
-## Permissions
-
-This action uses AWS Signer to sign images. Ensure your GitHub Actions workflow has the necessary AWS credentials configured (via environment variables, IAM roles, or other AWS authentication methods) to access AWS Signer.
 
 ## Usage
 
 Replace `docker/build-push-action@vX` with `rudderlabs/build-scan-push-action@v2.x`
 in your GitHub Workflows.
-
-### Required Inputs for Image Signing
-
-When using `push: true`, you must provide the following inputs for image signing:
-
-- `aws-signer-public-key`: Public key for AWS Signer
-- `aws-signer-profile-arn`: AWS Signer profile ARN
-
-Example:
-
-```yaml
-- uses: rudderlabs/build-scan-push-action@v2.x
-  with:
-    context: .
-    file: ./Dockerfile
-    tags: myimage:latest
-    push: true
-    aws-signer-public-key: ${{ secrets.AWS_SIGNER_PUBLIC_KEY }}
-    aws-signer-profile-arn: ${{ secrets.AWS_SIGNER_PROFILE_ARN }}
-```
 
 For more info, refer the documentation of
 [docker-build-push](https://github.com/docker/build-push-action) GitHub Action.
@@ -60,8 +35,6 @@ format. All paths that match these patterns are excluded in TruffleHog scans.
 
 This GitHub Action only accepts the following inputs.
 
-- `aws-signer-public-key`
-- `aws-signer-profile-arn`
 - `build-args`
 - `cache-from`
 - `cache-to`
@@ -82,27 +55,6 @@ If you want to use an input which is not in the above mentioned list,
 feel free to contribute or reach out to infra team for support.
 
 ## Upgrade Guide
-
-### From v1.x to v2.0
-
-Version 2.0 introduces breaking changes related to image signing. The action now uses **Notation CLI with AWS Signer** instead of **Cosign with GitHub OIDC/Fulcio**.
-
-#### Breaking Changes
-
-1. **Image Signing Method Changed**:
-   - **Removed**: Cosign signing with GitHub OIDC tokens
-   - **Added**: Notation CLI with AWS Signer
-
-2. **New Required Inputs** (when `push: true`):
-   - `aws-signer-public-key`: Public key for AWS Signer
-   - `aws-signer-profile-arn`: AWS Signer profile ARN
-
-3. **Removed Features**:
-   - Snyk scanning support has been removed (snyk-enabled, snyk-token, snyk-org, snyk-project-name inputs)
-
-4. **Permissions Changes**:
-   - **Removed**: `id-token: write` permission is no longer required (was needed for OIDC-based signing)
-   - **Added**: AWS credentials must be configured for AWS Signer access
 
 ### From v1.4.x to v1.5.x
 

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         fi
 
     - name: Build image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
@@ -100,7 +100,7 @@ runs:
         outputs: type=docker,dest=${{ runner.temp }}/local-docker-image.tar
 
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       with:
         python-version: "3.x"
 
@@ -143,7 +143,7 @@ runs:
     - name: Build and push
       id: build-and-push
       if: success()
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}

--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,6 @@ inputs:
   target:
     description: "Set the target build stage to build"
     required: false
-  aws-signer-public-key:
-    description: "Public key for AWS Signer"
-    required: false
-  aws-signer-profile-arn:
-    description: "AWS Signer profile ARN"
-    required: false
 
 outputs:
   imageid:
@@ -159,26 +153,3 @@ runs:
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         target: ${{ inputs.target }}
-
-    - name: Setup Notation CLI
-      if: ${{ inputs.push == 'true' }}
-      uses: rudderlabs/setup-aws-signer-notation-cli@2cdd7a8d005b02a80a122a2059d51434ed69ee90
-      with:
-        public-key: ${{ inputs.aws-signer-public-key }}
-
-    - name: Sign the images using Notation CLI
-      if: ${{ inputs.push == 'true' }}
-      env:
-        AWS_SIGNER_PROFILE_ARN: ${{ inputs.aws-signer-profile-arn }}
-        DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        TAGS: ${{ inputs.tags }}
-      shell: bash
-      run: |
-        for tag in ${TAGS}; do
-          echo "Signing image: ${tag}@${DIGEST}"
-          notation sign -v \
-          ${tag}@${DIGEST} \
-          --force-referrers-tag=false \
-          --plugin "com.amazonaws.signer.notation.plugin" \
-          --id "${AWS_SIGNER_PROFILE_ARN}"
-        done


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0
Bringing the latest changes to the main branch.

Linear Ticket: [INF-1624](https://linear.app/rudderstack/issue/INF-1624/create-a-new-build-scan-push-action-version-without-signing-logic)