### PR TITLE
fix: prevent raw secrets from leaking into GitHub Actions logs

### DIFF
--- a/docker-image-scanner.py
+++ b/docker-image-scanner.py
@@ -107,7 +107,14 @@ def main():
                 .get("Docker", {})
                 .get("layer", "")
             )
-            redacted_secret = finding["Redacted"] if finding["Redacted"] != "" else finding["Raw"]
+            raw = finding.get("Raw", "")
+            redacted = finding.get("Redacted", "")
+            if redacted:
+                redacted_secret = redacted
+            elif raw:
+                redacted_secret = raw[:4] + "****" if len(raw) > 4 else "****"
+            else:
+                redacted_secret = "****"
             detector = finding["DetectorName"]
             print(
                 f"Found unverified secret of type='{detector}' with value='{redacted_secret}' in file={file} layer={layer}"


### PR DESCRIPTION
## Summary

- **Security fix**: When TruffleHog's detector doesn't implement redaction (`Redacted` field is empty), the scanner was falling back to printing the full `Raw` secret value into GitHub Actions logs
- Now truncates to the first 4 characters + `****` when redaction is unavailable, providing enough context to identify the credential without exposing it
- Reported via HackerOne

## Test plan

- [x] Build a Docker image containing a secret whose TruffleHog detector does not implement redaction
- [x] Run the action and verify logs show only truncated values (e.g. `sk-t****`) instead of the full secret
- [x] Verify secrets with proper TruffleHog redaction still display the redacted form as before